### PR TITLE
light/dark support switch

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,0 +1,9 @@
+@import '~vuetify/src/styles/styles.sass';
+$light-background-color: #fff;
+$material-light: map-merge($material-light, ('background': $light-background-color));
+
+.theme--light {
+    .v-application--wrap {
+        background: $light-background-color
+    }
+}

--- a/components/Cities.vue
+++ b/components/Cities.vue
@@ -6,6 +6,7 @@
           <v-alert colored-border :color="createRandomColor()" border="left">
             <nuxt-link :to="`/radio/${country}/${i.slug}`">
               <span
+                :class="isDarkTheme ? 'white--text' : 'black--text'"
                 class="w-100 fill-height text-truncate white--text font-weight-medium"
                 >{{ i.name }}</span
               >
@@ -37,6 +38,11 @@ export default {
       this.cities = country.cities;
     } catch (e) {
       console.error(e);
+    }
+  },
+  computed: {
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`]
     }
   },
   methods: {

--- a/components/Countries.vue
+++ b/components/Countries.vue
@@ -5,6 +5,7 @@
         <v-alert colored-border :color="createRandomColor()" border="left">
           <nuxt-link :to="`/radio/${i.slug}`">
             <span
+              :class="isDarkTheme ? 'white--text' : 'black--text'"
               class="w-100 fill-height text-truncate white--text font-weight-medium"
               >{{ i.name }}</span
             >
@@ -27,6 +28,11 @@ export default {
       this.countries = await this.$api.getCountries();
     } catch (e) {
       console.error(e);
+    }
+  },
+  computed: {
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`];
     }
   },
   methods: {

--- a/components/Genres.vue
+++ b/components/Genres.vue
@@ -5,6 +5,7 @@
         <v-alert colored-border :color="createRandomColor()" border="left">
           <nuxt-link :to="`/radio/genre/${i.slug}`">
             <span
+              :class="isDarkTheme ? 'white--text' : 'black--text'"
               class="w-100 fill-height text-truncate white--text font-weight-medium"
               >{{ i.name }}</span
             >
@@ -23,6 +24,11 @@ export default {
       default() {
         return []
       }
+    }
+  },
+  computed: {
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`]
     }
   },
   methods: {

--- a/components/PageMenu.vue
+++ b/components/PageMenu.vue
@@ -15,7 +15,7 @@
         > -->
         <v-chip
           class="subtitle-1 px-6 font-weight-medium"
-          outlined
+          :outlined="isDarkTheme"
           :large="$vuetify.breakpoint.mdAndUp"
           :color="createRandomColor()"
           to="/radio/genre"
@@ -25,7 +25,7 @@
         >
         <v-chip
           class="subtitle-1 px-6 font-weight-medium"
-          outlined
+          :outlined="isDarkTheme"
           :large="$vuetify.breakpoint.mdAndUp"
           to="/radio/by-location"
           exact
@@ -40,6 +40,11 @@
 
 <script>
 export default {
+  computed: {
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`]
+    }
+  },
   methods: {
     createRandomColor() {
       return "hsla(" + Math.random() * 360 + ", 70%, 65%, 1)";

--- a/components/Radio/RadioHeader.vue
+++ b/components/Radio/RadioHeader.vue
@@ -18,9 +18,9 @@
               <v-img :src="radio.picture" max-width="265" max-height="265" />
             </v-col>
             <v-col align-self="center" class="flex-grow-1 flex-shrink-0">
-              <h1 class="text-h2">{{ radio.name }}</h1>
-              <p>{{ radio.country.name }}</p>
-              <div class="subtitle-1 min-h-24">
+              <h1 class="text-h2 white--text">{{ radio.name }}</h1>
+              <p class="white--text">{{ radio.country.name }}</p>
+              <div class="subtitle-1 min-h-24 white--text">
                 <v-flex class="d-flex flex-row">
                   <!-- TODO: Disabled Placeholder social links
                   <v-btn icon :href="radio.website" target="_blank">
@@ -64,7 +64,7 @@
                 <v-menu bottom left>
                   <template v-slot:activator="{ on }">
                     <v-btn icon class="ml-4" v-on="on">
-                      <v-icon>mdi-dots-vertical</v-icon>
+                      <v-icon color="white">mdi-dots-vertical</v-icon>
                     </v-btn>
                   </template>
                   <v-list tile class="py-0">
@@ -113,6 +113,11 @@ export default {
     return {
       showDetails: false
     };
+  },
+  computed: {
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`];
+    }
   },
   methods: {
     onPlay(item) {

--- a/components/ToolbarContent.vue
+++ b/components/ToolbarContent.vue
@@ -10,7 +10,7 @@
         alt="BitSong"
         min-width="135"
         width="135"
-        src="/bitsong_logo_red.svg"
+        :src="isDarkTheme ? '/bitsong_logo_dark.svg' : '/bitsong_logo_light.svg'"
       />
     </router-link>
 
@@ -48,6 +48,9 @@ export default {
   computed: {
     isLoggedIn() {
       return this.$store.getters[`wallet/isLoggedIn`];
+    },
+    isDarkTheme() {
+      return this.$store.getters[`dark_theme`];
     }
   }
 };

--- a/components/TrackGridItem.vue
+++ b/components/TrackGridItem.vue
@@ -23,7 +23,10 @@
         >{{ item.name }}</router-link
       >
     </div>
-    <div class="text-wrap track-grid__item_subtitle">
+    <div
+      :class="isDarkTheme ? 'white--text' : 'black--text'"
+      class="text-wrap track-grid__item_subtitle"
+    >
       {{ item.city.name }},
       <router-link nuxt :to="`/radio/${item.country.slug}`">{{
         item.country.name
@@ -88,6 +91,9 @@ export default {
     },
     isLoading() {
       return this.$store.getters["player/loading"];
+    },
+    isDarkTheme() {
+      return this.$store.getters[`app/dark_theme`];
     }
   }
 };


### PR DESCRIPTION
This pull request add the full support for theme switch with consistency color contrast for all radio frontend components.
In the variable.css file now there the variable **$light-background-color** for set the global light theme background color. 